### PR TITLE
ES basic auth request doesn't include password

### DIFF
--- a/src/lib/consumers/ElasticSearch/index.js
+++ b/src/lib/consumers/ElasticSearch/index.js
@@ -55,8 +55,8 @@ module.exports = function (context) {
     };
     if (config.username) {
         clientConfig.httpAuth = config.username;
-        if (config.password) {
-            clientConfig.httpAuth = `${clientConfig.httpAuth}:${config.password}`;
+        if (config.passphrase) {
+            clientConfig.httpAuth = `${clientConfig.httpAuth}:${config.passphrase}`;
         }
     }
     if (config.apiVersion) {


### PR DESCRIPTION
@dstokesf5 

#### What issues does this address?

Request to ElasticSearch doesn't include password in basic auth header.

#### What does this change do?
config object has no attribute "password" changed it to use "passphrase"

#### Where should the reviewer start?
Tried with setting up a fresh ES cluster with basic auth, observed that password is not included in basic auth header.

#### Any background context?
N/A