### PR TITLE
Adding eventSchemaVersion to F5_Cloud Consumer Schema

### DIFF
--- a/examples/declarations/f5_cloud.json
+++ b/examples/declarations/f5_cloud.json
@@ -90,7 +90,8 @@
       "authProviderX509CertUrl": "https://www.googleapis.com/oauth2/v1/certs",
       "clientX509CertUrl": "https://www.googleapis.com/robot/v1/metadata/x509/test%40deos-dev.iam.gserviceaccount.com"
     },
-    "targetAudience": "deos-ingest"
+    "targetAudience": "deos-ingest",
+    "eventSchemaVersion": "5"
   },
   "schemaVersion": "1.15.0"
 }

--- a/src/lib/consumers/F5_Cloud/index.js
+++ b/src/lib/consumers/F5_Cloud/index.js
@@ -107,7 +107,7 @@ module.exports = function (context) {
                 timestamp_usec: Date.now() * 1000,
                 signature_type: 0,
                 serialization_type: 1,
-                payload: Buffer.from(data.data), 'utf8'),
+                payload: Buffer.from(data.data, 'utf8'),
                 payload_schema: `urn:${context.config.payloadSchemaNid}:big-ip:event-schema:${configSchema.toLowerCase()}:v${context.config.event_schema_version}`
             };
 

--- a/src/lib/consumers/F5_Cloud/index.js
+++ b/src/lib/consumers/F5_Cloud/index.js
@@ -107,14 +107,14 @@ module.exports = function (context) {
                 timestamp_usec: Date.now() * 1000,
                 signature_type: 0,
                 serialization_type: 1,
-                payload: Buffer.from(JSON.stringify(data), 'utf8'),
-                payload_schema: `urn:${context.config.payloadSchemaNid}:big-ip:event-schema:${configSchema.toLowerCase()}:v1`
+                payload: Buffer.from(data.data), 'utf8'),
+                payload_schema: `urn:${context.config.payloadSchemaNid}:big-ip:event-schema:${configSchema.toLowerCase()}:v${context.config.event_schema_version}`
             };
 
             context.logger.debug(`account_id : ${ingestionRequest.account_id}`);
             context.logger.debug(`source_id : ${ingestionRequest.source_id}`);
             context.logger.debug(`payload_schema : ${ingestionRequest.payload_schema}`);
-            context.logger.debug(`data : ${JSON.stringify(data)}`);
+            context.logger.debug(`data : ${data.data}`);
 
             return new Promise((resolve) => {
                 client.post(ingestionRequest, metadata, (err, response) => {

--- a/src/schema/latest/consumer_schema.json
+++ b/src/schema/latest/consumer_schema.json
@@ -400,6 +400,14 @@
                 }
             ]
         },
+        "eventSchemaVersion": {
+            "$comment": "Required for certain consumers: F5_Cloud",
+            "title": "Event Schema Version",
+            "description": "" ,
+            "type": "integer",
+            "minLength": 1,
+            "f5expand": true
+        },
         "f5csTenantId": {
             "$comment": "Required for certain consumers: F5_Cloud",
             "title": "F5CS Tenant ID",
@@ -667,6 +675,7 @@
                             "clientCertificate": {},
                             "rootCertificate": {},
                             "fallbackHosts": {},
+                            "eventSchemaVersion": {},
                             "f5csTenantId": {},
                             "f5csSensorId": {},
                             "payloadSchemaNid": {},
@@ -1082,6 +1091,7 @@
                         "if": { "properties": { "type": { "const": "F5_Cloud" } } },
                         "then": {
                             "required": [
+                                "eventSchemaVersion",
                                 "f5csTenantId",
                                 "f5csSensorId",
                                 "payloadSchemaNid",
@@ -1090,6 +1100,7 @@
                             ],
                             "properties": {
                                 "port": { "$ref": "#/definitions/port", "default": 443 },
+                                "eventSchemaVersion": { "$ref": "#/definitions/eventSchemaVersion" },
                                 "f5csTenantId": { "$ref": "#/definitions/f5csTenantId" },
                                 "f5csSensorId": { "$ref": "#/definitions/f5csSensorId" },
                                 "payloadSchemaNid": { "$ref": "#/definitions/payloadSchemaNid" },


### PR DESCRIPTION
@dstokesf5 

#### What issues does this address?

- Fixes #141

#### What does this change do?

Adds eventSchemaVersion to F5_Cloud declaration schema to allow interacting with different schema versions.

#### Where should the reviewer start?

src/lib/consumers/F5_Cloud/index.js

#### Any background context?

This is for work with Lumen.