### PR TITLE
Add config for azure urls

### DIFF
--- a/docs/setting-up-consumer.rst
+++ b/docs/setting-up-consumer.rst
@@ -147,6 +147,10 @@ The following items have been added to the Azure Log Analytics consumer since it
         - **region**
         - The **region** property for Azure Log Analytics and Application Insights was added in part to support the Azure Government regions. |br| - This optional property is used to determine cloud type (public/commercial, govcloud) so that the correct API URLs can be used (example values: westeurope, japanwest, centralus, usgovvirginia, and so on). |br| - If you do not provide a region, Telemetry Streaming attempts to look it up from the instance metadata. |br| - If it is unable to extract metadata, TS defaults to public/commercial |br| - Check the |azregion| for product/region compatibility for Azure Government. |br| - See the Azure documentation for a valid list of regions (resource location), and :ref:`Region list<azreg>` for example values from the Azure CLI.
 
+      * - 1.31
+        - **customOpts**
+        - The **customOpts** property for Azure Log Analytics was added to support "managementUrl" and "opinsightsUrl" options that enable the use of the TC in environments where the cloud URLs can not be publicly published. Setting these values in the consumer configuration will override the calculated value based on region.
+
 
 
 To see more information about sending data to Log Analytics, see |HTTP Data Collector API|.
@@ -159,6 +163,11 @@ To see more information about sending data to Log Analytics, see |HTTP Data Coll
 Example Declaration:
 
 .. literalinclude:: ../examples/declarations/azure_log_analytics.json
+    :language: json
+
+Example Declaration with `customOps` (available in TC 1.31)
+
+.. literalinclude:: ../examples/declarations/azure_log_analytics_customOpts.json
     :language: json
 
 
@@ -1093,7 +1102,9 @@ In the following table, we list the Azure Government regions.
 | USGov Arizona        |  33.4484   | -112.0740  | usgovarizona       |
 +----------------------+------------+------------+--------------------+
 
+|
 
+If you are using this tool in a cloud other than Azure Public or Azure Government, use the `managementUrl` and `opinsightsUrl` options for the `customOpts` array to specifically set the URLs.
 
 
 .. |splunk_img| image:: /images/splunk_logo.png

--- a/examples/declarations/azure_log_analytics_customOpts.json
+++ b/examples/declarations/azure_log_analytics_customOpts.json
@@ -1,0 +1,21 @@
+{
+    "class": "Telemetry",
+    "My_Consumer": {
+        "class": "Telemetry_Consumer",
+        "type": "Azure_Log_Analytics",
+        "workspaceId": "workspaceid",
+        "passphrase": {
+            "cipherText": "sharedkey"
+        },
+        "useManagedIdentity": false,
+        "region": "westus",
+        "format": "propertyBased",
+        "customOpts": [{
+            "name": "managementUrl",
+            "value": "https://management.azure.de"
+        },{
+            "name": "opinsightsUrl",
+            "value": "https://workspaceId.ods.opinsights.azure.de/api/logs?api-version=2016-04-01"
+        }]
+    }
+}

--- a/src/lib/consumers/shared/azureUtil.js
+++ b/src/lib/consumers/shared/azureUtil.js
@@ -10,7 +10,7 @@
 
 const crypto = require('crypto');
 const hasProperty = require('lodash/has');
-const logging = require('../../logging');
+const logger = require('../../logger');
 const promiseUtil = require('../../utils/promise');
 const requestsUtil = require('../../utils/requests');
 
@@ -109,7 +109,7 @@ function getApiUrl(context, apiType) {
     // }
     const url = getCustomOptionForApiUrl(context, `${apiType}Url`);
     if (url) {
-        logging.debug(`using custom API URL ${url}`);
+        logger.debug(`using custom API URL ${url}`);
         return url;
     }
 

--- a/src/lib/consumers/shared/azureUtil.js
+++ b/src/lib/consumers/shared/azureUtil.js
@@ -70,7 +70,47 @@ function getApiDomain(region, apiType) {
     }
 }
 
+function getCustomOptionForApiUrl(option) {
+    if (context.config.customOpts) {
+        const optionData = context.config.customOpts.find(element => element.name === option);
+        if (optionData) {
+            return optionData.value.toString();
+        }
+    }
+
+    return '';
+}
+
 function getApiUrl(context, apiType) {
+    // If the user specified a URL in the customOpts configuration, use that instead of calculating a URL. Example:
+    // {
+    //     "class": "Telemetry",
+    //     "My_Consumer": {
+    //         "class": "Telemetry_Consumer",
+    //         "type": "Azure_Log_Analytics",
+    //         "workspaceId": "workspaceid",
+    //         "passphrase": {
+    //             "cipherText": "sharedkey"
+    //         },
+    //         "useManagedIdentity": false,
+    //         "format": "propertyBased",
+    //         "customOpts": [
+    //              {
+    //                  "name": "managementUrl",
+    //                  "value": " https://management.azure.cn"
+    //              },
+    //              {
+    //                  "name": "opinsightsUrl",
+    //                  "value": " https://workspaceid.ods.opinsights.azure.cn/api/logs?api-version=2016-04-01"
+    //              }
+    //          ]
+    //     }
+    // }
+    const url = getCustomOptionForApiUrl(`${apiType}Url`);
+    if (url) {
+        return url;
+    }
+
     const region = getInstanceRegion(context);
     const domain = getApiDomain(region, apiType);
     if (apiType === AZURE_API_TYPES.OPINSIGHTS) {

--- a/src/lib/consumers/shared/azureUtil.js
+++ b/src/lib/consumers/shared/azureUtil.js
@@ -10,6 +10,7 @@
 
 const crypto = require('crypto');
 const hasProperty = require('lodash/has');
+const logging = require('../../logging');
 const promiseUtil = require('../../utils/promise');
 const requestsUtil = require('../../utils/requests');
 
@@ -70,7 +71,7 @@ function getApiDomain(region, apiType) {
     }
 }
 
-function getCustomOptionForApiUrl(option) {
+function getCustomOptionForApiUrl(context, option) {
     if (context.config.customOpts) {
         const optionData = context.config.customOpts.find(element => element.name === option);
         if (optionData) {
@@ -97,17 +98,18 @@ function getApiUrl(context, apiType) {
     //         "customOpts": [
     //              {
     //                  "name": "managementUrl",
-    //                  "value": " https://management.azure.cn"
+    //                  "value": "https://management.azure.cn"
     //              },
     //              {
     //                  "name": "opinsightsUrl",
-    //                  "value": " https://workspaceid.ods.opinsights.azure.cn/api/logs?api-version=2016-04-01"
+    //                  "value": "https://workspaceid.ods.opinsights.azure.cn/api/logs?api-version=2016-04-01"
     //              }
     //          ]
     //     }
     // }
-    const url = getCustomOptionForApiUrl(`${apiType}Url`);
+    const url = getCustomOptionForApiUrl(context, `${apiType}Url`);
     if (url) {
+        logging.debug(`using custom API URL ${url}`);
         return url;
     }
 

--- a/src/schema/1.31.0/actions_schema.json
+++ b/src/schema/1.31.0/actions_schema.json
@@ -1,0 +1,187 @@
+{
+    "$id": "actions_schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry Streaming Actions schema",
+    "description": "",
+    "type": "object",
+    "definitions": {
+        "baseActionsChain": {
+            "title": "Chain of Actions",
+            "description": "Actions to be performed on the data.",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/baseActionObject"
+            }
+        },
+        "baseActionObject": {
+            "title": "Base Action object",
+            "description": "Base object to build actions.",
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "title": "Enable",
+                    "description": "Whether to enable this action in the declaration or not.",
+                    "type": "boolean",
+                    "default": true
+                }
+            }
+        },
+        "baseConditionalActionObject": {
+            "title": "Base Action object with support for conditional statements",
+            "description": "Base Action object with support for conditional statements.",
+            "type": "object",
+            "allOf": [
+                { "$ref": "#/definitions/baseActionObject" },
+                {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "ifAllMatch": {
+                                    "title": "If All Match",
+                                    "description": "The conditions that will be checked against. All must be true.",
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            },
+                            "not": { "required": ["ifAnyMatch"] }
+                        },
+                        {
+                            "properties": {
+                                "ifAnyMatch": {
+                                    "title": "If Any Match",
+                                    "description": "An array of ifAllMatch objects. Any individual ifAllMatch object may match, but each condition within an ifAllMatch object must be true",
+                                    "type": "array"
+                                }
+                            },
+                            "not": { "required": ["ifAllMatch"] }
+                        }
+                    ]
+                }
+            ]
+        },
+        "subLocation": {
+            "title": "Location",
+            "description": "Used to specify a location in TS data. Use boolean type with value true to specify the location.",
+            "oneOf": [
+                {
+                    "type": "boolean",
+                    "const": true
+                },
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/subLocation"
+                    }
+                }
+            ]
+        },
+        "locations": {
+            "title": "Location",
+            "description": "The location(s) to apply the action.",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/subLocation"
+            }
+        },
+        "setTagAction": {
+            "title": "setTag Action",
+            "description": "Action to assign a tag(s) to particular or default location",
+            "type": "object",
+            "allOf": [
+                { "$ref": "#/definitions/baseConditionalActionObject" },
+                {
+                    "properties": {
+                        "setTag": {
+                            "title": "Set Tag",
+                            "description": "The tag values to be added.",
+                            "type": "object",
+                            "additionalProperties": true
+                        },
+                        "locations": {
+                            "title": "Location",
+                            "description": "The location(s) to apply the action.",
+                            "allOf": [{ "$ref": "#/definitions/locations" }]
+                        },
+                        "enable": {},
+                        "ifAllMatch": {},
+                        "ifAnyMatch": {}
+                    },
+                    "additionalProperties": false,
+                    "required": ["setTag"]
+                }
+            ]
+        },
+        "includeDataAction": {
+            "title": "includeData Action",
+            "description": "Action to specify data fields to include in the output",
+            "type": "object",
+            "allOf": [
+                { "$ref": "#/definitions/baseConditionalActionObject" },
+                {
+                    "properties": {
+                        "includeData": {
+                            "title": "Include Data",
+                            "description": "The data fields to include in the output",
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "locations": {
+                            "title": "Location",
+                            "description": "The location(s) to apply the action.",
+                            "allOf": [{ "$ref": "#/definitions/locations" }]
+                        },
+                        "enable": {},
+                        "ifAllMatch": {},
+                        "ifAnyMatch": {}
+                    },
+                    "additionalProperties": false,
+                    "required": ["includeData", "locations"]
+                }
+            ]
+        },
+        "excludeDataAction": {
+            "title": "excludeData Action",
+            "description": "Action to specify data fields to exclude form the output",
+            "type": "object",
+            "allOf": [
+                { "$ref": "#/definitions/baseConditionalActionObject" },
+                {
+                    "properties": {
+                        "excludeData": {
+                            "title": "Exclude Data",
+                            "description": "The data fields to exclude from the output",
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "locations": {
+                            "title": "Location",
+                            "description": "The location(s) to apply the action.",
+                            "allOf": [{ "$ref": "#/definitions/locations" }]
+                        },
+                        "enable": {},
+                        "ifAllMatch": {},
+                        "ifAnyMatch": {}
+                    },
+                    "additionalProperties": false,
+                    "required": ["excludeData", "locations"]
+                }
+            ]
+        },
+        "inputDataStreamActionsChain": {
+            "title": "",
+            "description": "",
+            "allOf": [
+                { "$ref": "#/definitions/baseActionsChain" },
+                {
+                    "items": {
+                        "oneOf": [
+                            { "$ref": "#/definitions/excludeDataAction" },
+                            { "$ref": "#/definitions/includeDataAction" },
+                            { "$ref": "#/definitions/setTagAction" }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/src/schema/1.31.0/base_schema.json
+++ b/src/schema/1.31.0/base_schema.json
@@ -1,0 +1,310 @@
+{
+    "$id": "base_schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry Streaming",
+    "description": "",
+    "type": "object",
+    "definitions": {
+        "enable": {
+            "title": "Enable",
+            "description": "This property can be used to enable/disable the poller/listener" ,
+            "type": "boolean"
+        },
+        "trace": {
+            "title": "Trace",
+            "description": "Enables data dumping to file. Boolean uses pre-defined file location, however value could be a string which contains path to a specific file instead" ,
+            "minLength": 1,
+            "type": ["boolean", "string"]
+        },
+        "traceConfig": {
+            "title": "Trace (v2)",
+            "description": "Enables data dumping to file. Boolean uses pre-defined file location, however value could be a string which contains path to a specific file instead",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "title": "Trace type",
+                    "description": "Trace type - output data or input data",
+                    "type": "string",
+                    "enum": ["output", "input"]
+                },
+                "path": {
+                    "title": "Path to trace file",
+                    "description": "Path to trace file to write data to",
+                    "type": "string",
+                    "minLength": 1
+                }
+            },
+            "required": ["type"]
+        },
+        "traceV2": {
+            "title": "Trace (v2)",
+            "description": "Enables data dumping to file. Boolean uses pre-defined file location, however value could be a string which contains path to a specific file instead",
+            "oneOf": [
+                { "$ref": "#/definitions/traceConfig" },
+                {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 2,
+                    "uniqueItemProperties": ["type"],
+                    "items": {
+                        "allOf": [{
+                            "$ref": "#/definitions/traceConfig"
+                        }]
+                    }
+                }
+            ]
+        },
+        "secret": {
+            "title": "Passphrase (secret)",
+            "description": "" ,
+            "type": "object",
+            "properties": {
+                "class": {
+                    "title": "Class",
+                    "description": "Telemetry streaming secret class",
+                    "type": "string",
+                    "enum": [ "Secret" ],
+                    "default": "Secret"
+               },
+                "cipherText": {
+                    "title": "Cipher Text: this contains a secret to encrypt",
+                    "type": "string"
+                },
+                "environmentVar": {
+                    "title": "Environment Variable: this contains the named env var where the secret resides",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "protected": {
+                    "$comment": "Meta property primarily used to determine if 'cipherText' needs to be encrypted",
+                    "title": "Protected",
+                    "type": "string",
+                    "enum": [ "plainText", "plainBase64", "SecureVault" ],
+                    "default": "plainText"
+                }
+            },
+            "oneOf": [
+                { "required": [ "cipherText" ] },
+                { "required": [ "environmentVar" ] }
+            ],
+            "f5secret": true
+        },
+        "username": {
+            "$comment": "Common field for username to use everywhere in scheme",
+            "title": "Username",
+            "type": "string",
+            "minLength": 1
+        },
+        "stringOrSecret": {
+            "allOf": [
+                {
+                    "if": { "type": "string" },
+                    "then": {},
+                    "else": {}
+                },
+                {
+                    "if": { "type": "object" },
+                    "then": { "$ref": "base_schema.json#/definitions/secret" },
+                    "else": {}
+                }
+            ]
+        },
+        "constants": {
+            "title": "Constants",
+            "description": "" ,
+            "type": "object",
+            "properties": {
+                "class": {
+                    "title": "Class",
+                    "description": "Telemetry streaming constants class",
+                    "type": "string",
+                    "enum": [ "Constants" ]
+               }
+            },
+            "additionalProperties": true
+        },
+        "tag": {
+            "$comment": "Defaults do not get applied for $ref objects, so place defaults alongside instead.",
+            "title": "Tag",
+            "description": "" ,
+            "type": "object",
+            "properties": {
+                "tenant": {
+                    "title": "Tenant tag",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "application": {
+                    "title": "Application tag",
+                    "type": "string",
+                    "minLength": 1
+                }
+            },
+            "additionalProperties": true
+        },
+        "match": {
+            "$comment": "Defaults do not get applied for $ref objects, so place defaults alongside instead.",
+            "title": "Pattern to filter data",
+            "description": "",
+            "type": "string"
+        },
+        "enableHostConnectivityCheck": {
+            "$comment": "This property can be used to enable/disable the host connectivity check in configurations where this is in effect",
+            "title": "Host",
+            "description": "" ,
+            "type": "boolean"
+        },
+        "allowSelfSignedCert": {
+            "$comment": "This property can be used by consumers, system pollers to enable/disable SSL Cert check",
+            "title": "Allow Self-Signed Certificate",
+            "description": "" ,
+            "type": "boolean"
+        },
+        "host": {
+            "$comment": "This property can be used by consumers, system pollers",
+            "title": "Host",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "anyOf": [
+                { "format": "ipv4" },
+                { "format": "ipv6" },
+                { "format": "hostname" }
+            ],
+            "hostConnectivityCheck": true
+        },
+        "port": {
+            "title": "Port",
+            "description": "" ,
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 65535
+        },
+        "protocol": {
+            "title": "Protocol",
+            "description": "" ,
+            "type": "string",
+            "enum": [ "http", "https" ]
+        },
+        "proxy": {
+            "title": "Proxy Configuration",
+            "description": "",
+            "type": "object",
+            "dependencies": {
+                "passphrase": [ "username" ]
+            },
+            "required": [ "host" ],
+            "properties": {
+                "host": {
+                    "$ref": "#/definitions/host"
+                },
+                "port": {
+                    "default": 80,
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/port"
+                        }
+                    ]
+                },
+                "protocol": {
+                    "default": "http",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/protocol"
+                        }
+                    ]
+                },
+                "enableHostConnectivityCheck": {
+                    "$ref": "#/definitions/enableHostConnectivityCheck"
+                },
+                "allowSelfSignedCert": {
+                    "$ref": "#/definitions/allowSelfSignedCert"
+                },
+                "username": {
+                    "$ref": "#/definitions/username"
+                },
+                "passphrase": {
+                    "$ref": "#/definitions/secret"
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "properties": {
+       "class": {
+            "title": "Class",
+            "description": "Telemetry streaming top level class",
+            "type": "string",
+            "enum": [ "Telemetry" ]
+       },
+       "schemaVersion": {
+            "title": "Schema version",
+            "description": "Version of ADC Declaration schema this declaration uses",
+            "type": "string",
+            "$comment": "IMPORTANT: In enum array, please put current schema version first, oldest-supported version last.  Keep enum array sorted most-recent-first.",
+            "enum": [ "1.31.0", "1.30.0", "1.29.0", "1.28.0", "1.27.1", "1.27.0", "1.26.0", "1.25.0", "1.24.0", "1.23.0", "1.22.0", "1.21.0", "1.20.1", "1.20.0", "1.19.0", "1.18.0", "1.17.0", "1.16.0", "1.15.0", "1.14.0",  "1.13.0", "1.12.0", "1.11.0", "1.10.0", "1.9.0", "1.8.0", "1.7.0", "1.6.0", "1.5.0", "1.4.0", "1.3.0", "1.2.0", "1.1.0", "1.0.0", "0.9.0" ],
+            "default": "1.31.0"
+       },
+       "$schema": {
+            "title": "Schema",
+            "description": "",
+            "type": "string"
+        }
+    },
+    "additionalProperties": {
+        "$comment": "AJV does not resolve defaults inside oneOf/anyOf, so instead use allOf.  Any schema refs should also use allOf with an if/then/else on class",
+        "properties": {
+            "class": {
+                "title": "Class",
+                "type": "string",
+                "enum": [
+                    "Telemetry_System",
+                    "Telemetry_System_Poller",
+                    "Telemetry_Listener",
+                    "Telemetry_Consumer",
+                    "Telemetry_Pull_Consumer",
+                    "Telemetry_iHealth_Poller",
+                    "Telemetry_Endpoints",
+                    "Telemetry_Namespace",
+                    "Controls",
+                    "Shared"
+                ]
+            }
+        },    
+        "allOf": [
+            {
+                "$ref": "system_schema.json#"
+            },
+            {
+                "$ref": "system_poller_schema.json#"
+            },
+            {
+                "$ref": "listener_schema.json#"
+            },
+            {
+                "$ref": "consumer_schema.json#"
+            },
+            {
+                "$ref": "pull_consumer_schema.json#"
+            },
+            {
+                "$ref": "ihealth_poller_schema.json#"
+            },
+            {
+                "$ref": "endpoints_schema.json#"
+            },
+            {
+                "$ref": "controls_schema.json#"
+            },
+            {
+                "$ref": "shared_schema.json#"
+            },
+            {
+                "$ref": "namespace_schema.json#"
+            }
+        ]
+    },
+    "required": [
+        "class"
+    ]
+}

--- a/src/schema/1.31.0/consumer_schema.json
+++ b/src/schema/1.31.0/consumer_schema.json
@@ -1,0 +1,1387 @@
+{
+    "$id": "consumer_schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry Streaming Consumer schema",
+    "description": "",
+    "type": "object",
+    "definitions": {
+        "jmesPathAction": {
+            "title": "JMESPath Action",
+            "description": "Will use a JMESPath expression to modify the incoming data payload",
+            "type": "object",
+            "allOf": [
+                { "$ref": "actions_schema.json#/definitions/baseActionObject" },
+                {
+                    "properties": {
+                        "JMESPath": {
+                            "title": "JMESPath",
+                            "description": "Will use a JMESPath expression to modify the incoming data payload",
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "expression": {
+                            "title": "Expression",
+                            "description": "The JMESPath expression to be applied to the incoming data payload",
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "enable": {}
+                    },
+                    "additionalProperties": false,
+                    "required": ["JMESPath", "expression"]
+                }
+            ]
+        },
+        "autoTaggingStatsd": {
+            "title": "Statsd auto tagging",
+            "description": "Will parse incoming payload for values to automatically add as tags.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "title": "AutoTagging method",
+                    "description": "AutoTagging method to use to fetch tags",
+                    "type": "string",
+                    "enum": ["sibling"]
+                }
+            },
+            "additionalProperties": false,
+            "required": ["method"]
+        },
+        "genericHttpActions": {
+            "title": "Actions",
+            "description": "Actions to be performed on the Generic HTTP Consumer.",
+            "allOf": [
+                { "$ref": "actions_schema.json#/definitions/baseActionsChain" },
+                {
+                    "items": {
+                        "oneOf": [
+                            { "$ref": "#/definitions/jmesPathAction" }
+                        ]
+                    }
+                }
+            ]
+        },
+        "host": {
+            "$comment": "Required for certain consumers: standard property",
+            "title": "Host",
+            "description": "FQDN or IP address" ,
+            "type": "string",
+            "minLength": 1,
+            "anyOf": [
+                { "format": "ipv4" },
+                { "format": "ipv6" },
+                { "format": "hostname" }
+            ],
+            "hostConnectivityCheck": true   
+        },
+        "protocols": {
+            "$comment": "Required for certain consumers: standard property",
+            "title": "Protocols (all)",
+            "description": "" ,
+            "type": "string",
+            "enum": [ "https", "http", "tcp", "udp", "binaryTcpTls", "binaryTcp" ]
+        },
+        "port": {
+            "$comment": "Required for certain consumers: standard property",
+            "title": "Port",
+            "description": "" ,
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 65535
+        },
+        "path": {
+            "$comment": "Required for certain consumers: standard property",
+            "title": "Path",
+            "description": "Path to post data to",
+            "type": ["string", "object"],
+            "minLength": 1,
+            "f5expand": true,
+            "allOf": [
+                {
+                    "$ref": "base_schema.json#/definitions/stringOrSecret"
+                }
+            ]
+        },
+        "method": {
+            "$comment": "Required for certain consumers: standard property",
+            "title": "Method",
+            "description": "HTTP method to use (limited to sensical choices)" ,
+            "type": "string",
+            "enum": [ "POST", "GET", "PUT" ]
+        },
+        "headers": {
+            "$comment": "Required for certain consumers: standard property",
+            "title": "Headers",
+            "description": "HTTP headers to use" ,
+            "type": "array",
+            "items": {
+                "properties": {
+                    "name": {
+                        "description": "Name of this header",
+                        "type": "string",
+                        "f5expand": true,
+                        "minLength": 1
+                    },
+                    "value": {
+                        "description": "Value of this header",
+                        "type": ["string", "object"],
+                        "f5expand": true,
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/stringOrSecret"
+                            }
+                        ]
+                    }
+                },
+                "required": [
+                    "name",
+                    "value"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "customOpts": {
+            "$comment": "Required for certain consumers: standard property",
+            "title": "Custom Opts (Client Library Dependent)",
+            "description": "Additional options for use by consumer client library. Refer to corresponding consumer lib documentation for acceptable keys and values." ,
+            "type": "array",
+            "items": {
+                "properties": {
+                    "name": {
+                        "description": "Name of the option",
+                        "type": "string",
+                        "f5expand": true,
+                        "minLength": 1
+                    },
+                    "value": {
+                        "description": "Value of the option",
+                        "minLength": 1,
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "allOf": [
+                                    {
+                                        "f5expand": true
+                                    },
+                                    {
+                                        "$ref": "base_schema.json#/definitions/stringOrSecret"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "required": [
+                    "name",
+                    "value"
+                ],
+                "additionalProperties": false
+            },
+            "minItems": 1
+        },
+        "format": {
+            "$comment": "Required for certain consumers: Splunk and Azure_Log_Analytics",
+            "title": "Format (informs consumer additional formatting may be required)",
+            "description": "",
+            "type": "string"
+        },
+        "username": {
+            "$comment": "Required for certain consumers: standard property",
+            "title": "Username",
+            "description": "" ,
+            "minLength": 1,
+            "type": "string",
+            "f5expand": true
+        },
+        "region": {
+            "$comment": "Required for certain consumers: AWS_CloudWatch, AWS_S3, Azure_Log_Analytics, Azure_App_Insights, DataDog",
+            "title": "Region",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "endpointUrl": {
+            "$comment": "Required for certain consumers: AWS_CloudWatch, AWS_S3",
+            "title": "endpoint url",
+            "description": "The full endpoint URL for service requests",
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "bucket": {
+            "$comment": "Required for certain consumers: AWS_S3",
+            "title": "Bucket",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "maxAwsLogBatchSize": {
+            "$comment": "Required for certain consumers: AWS_CloudWatch",
+            "title": "Maximum Batch Size",
+            "description": "The maximum number of telemetry items to include in a payload to the ingestion endpoint",
+            "type": "integer",
+            "minimum": 1,
+            "default": 100,
+            "maximum": 10000
+        },
+        "logGroup": {
+            "$comment": "Required for certain consumers: AWS_CloudWatch",
+            "title": "Log Group",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "logStream": {
+            "$comment": "Required for certain consumers: AWS_CloudWatch",
+            "title": "Log Stream",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "metricNamespace": {
+            "$comment": "Required for certain consumers: AWS_CloudWatch",
+            "title": "Metric Namespace",
+            "description": "The namespace for the metrics",
+            "type": "string",
+            "f5expand": true,
+            "minLength": 1
+        },
+        "metricPrefix": {
+            "$comment": "Required for certain consumers: DataDog",
+            "title": "Metric Prefix",
+            "description": "The string value(s) to use as a metric prefix",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "allOf": [{
+                    "type": "string",
+                    "f5expand": true,
+                    "minLength": 1
+                }]
+            }
+        },
+        "workspaceId": {
+            "$comment": "Required for certain consumers: Azure_Log_Analytics",
+            "title": "Workspace ID",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "useManagedIdentity": {
+            "$comment": "Required for certain consumers: Azure_Log_Analytics and Azure_Application_Insights",
+            "title": "Use Managed Identity",
+            "description": "Determines whether to use Managed Identity to perform authorization for Azure services",
+            "type": "boolean",
+            "default": false
+        },
+        "appInsightsResourceName": {
+            "$comment": "Required for certain consumers: Azure_Application_Insights",
+            "title": "Application Insights Resource Name (Pattern)",
+            "description": "Name filter used to determine which App Insights resource to send metrics to. If not provided, TS will send metrics to App Insights in the subscription in which the managed identity has permissions to",
+            "type": "string",
+            "minLength": 1
+        },
+        "instrumentationKey": {
+            "$comment": "Required for certain consumers: Azure_Application_Insights",
+            "title": "Instrumentation Key",
+            "description": "Used to determine which App Insights resource to send metrics to",
+            "anyOf": [
+                {
+                    "type": "string",
+                    "f5expand": true,
+                    "minLength": 1
+                },
+                {
+                    "type":"array",
+                    "items": {
+                        "type": "string",
+                        "f5expand": true,
+                        "minLength": 1
+                    },
+                    "minItems": 1
+                }
+            ]
+        },
+        "maxBatchIntervalMs": {
+            "$comment": "Required for certain consumers: Azure_Application_Insights",
+            "title": "Maximum Batch Interval (ms)",
+            "description": "The maximum amount of time to wait in milliseconds to for payload to reach maxBatchSize",
+            "type": "integer",
+            "minimum": 1000,
+            "default": 5000
+        },
+        "maxBatchSize": {
+            "$comment": "Required for certain consumers: Azure_Application_Insights",
+            "title": "Maximum Batch Size",
+            "description": "The maximum number of telemetry items to include in a payload to the ingestion endpoint",
+            "type": "integer",
+            "minimum": 1,
+            "default": 250
+        },
+        "topic": {
+            "$comment": "Required for certain consumers: Kafka",
+            "title": "Topic",
+            "description": "" ,
+            "type": "string",
+            "f5expand": true
+        },
+        "index": {
+            "$comment": "Required for certain consumers: ElasticSearch",
+            "title": "Index Name",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "apiVersion": {
+            "$comment": "Required for certain consumers: ElasticSearch",
+            "title": "API Version",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "dataType": {
+            "$comment": "Required for certain consumers: AWS_CloudWatch, ElasticSearch",
+            "title": "Data type",
+            "description": "" ,
+            "type": "string",
+            "f5expand": true
+        },
+        "authenticationProtocol": {
+            "$comment": "Required for certain consumers: Kafka",
+            "title": "Authentication Protocol",
+            "description": "" ,
+            "type": "string",
+            "f5expand": true,
+            "enum": [
+                "SASL-PLAIN",
+                "TLS",
+                "None"
+            ]
+        },
+        "clientCertificate": {
+            "$comment": "Required for certain consumers: Kafka, Generic HTTP",
+            "title": "Client Certificate",
+            "description": "Certificate(s) to use when connecting to a secured endpoint.",
+            "type": "object",
+            "f5expand": true,
+            "allOf": [
+                {
+                    "$ref": "base_schema.json#/definitions/secret"
+                }
+            ]
+        },
+        "rootCertificate": {
+            "$comment": "Required for certain consumers: Kafka, Generic HTTP",
+            "title": "Root Certificate",
+            "description": "Certificate Authority root certificate, used to validate certificate chains.",
+            "type": "object",
+            "f5expand": true,
+            "allOf": [
+                {
+                    "$ref": "base_schema.json#/definitions/secret"
+                }
+            ]
+        },
+        "outputMode": {
+            "$comment": "Required for certain consumers: Generic HTTP",
+            "title": "output raw data flag",
+            "description": "Flag to request output of the raw data.",
+            "type": "string",
+            "enum": [ "processed", "raw" ]
+        },
+        "projectId": {
+            "$comment": "Required for certain consumers: Google_Cloud_Monitoring",
+            "title": "Project ID",
+            "description": "The ID of the relevant project.",
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "serviceEmail": {
+            "$comment": "Required for certain consumers: Google_Cloud_Monitoring, Google_Cloud_Logging",
+            "title": "Service Email",
+            "description": "The service email.",
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "privateKeyId": {
+            "$comment": "Required for certain consumers when Service Account Token is not used: Google_Cloud_Monitoring, Google_Cloud_Logging",
+            "title": "Private Key ID",
+            "description": "The private key ID.",
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "useServiceAccountToken": {
+            "$comment": "Used by certain consumers: Google_Cloud_Monitoring, Google_Cloud_Logging",
+            "title": "Use Service Account Token",
+            "description": "Determines whether to use Service Account Token to perform authorization for Google services",
+            "type": "boolean",
+            "default": false
+        },
+        "logScope": {
+            "$comment": "Required for certain consumers: Google_Cloud_Logging",
+            "title": "Logging Scope Type",
+            "description": "" ,
+            "enum": ["projects", "organizations", "billingAccounts", "folders"],
+            "f5expand": true
+        },
+        "logScopeId": {
+            "$comment": "Required for certain consumers: Google_Cloud_Logging",
+            "title": "Logging Scope ID",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "logId": {
+            "$comment": "Required for certain consumers: Google_Cloud_Logging",
+            "title": "Logging ID",
+            "description": "" ,
+            "type": "string",
+            "format": "regex",
+            "pattern": "^[a-zA-z0-9._-]+$",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "privateKey": {
+            "$comment": "Required for certain consumers: Kafka, Generic HTTP",
+            "title": "Private Key",
+            "description": "Private Key",
+            "type": "object",
+            "f5expand": true,
+            "allOf": [
+                {
+                    "$ref": "base_schema.json#/definitions/secret"
+                }
+            ]
+        },
+        "eventSchemaVersion": {
+            "$comment": "Required for certain consumers: F5_Cloud",
+            "title": "Event Schema Version",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true,
+            "default": "1"
+        },
+        "f5csTenantId": {
+            "$comment": "Required for certain consumers: F5_Cloud",
+            "title": "F5CS Tenant ID",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "f5csSensorId": {
+            "$comment": "Required for certain consumers: F5_Cloud",
+            "title": "F5CS Sensor ID",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "payloadSchemaNid": {
+            "$comment": "Required for certain consumers: F5_Cloud",
+            "title": "Namespace ID for payloadSchema",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "serviceAccount": {
+            "$comment": "Required for certain consumers: F5_Cloud",
+            "title": "Service Account",
+            "description": "Service Account to authentication" ,
+            "type": "object",
+            "properties": {
+                    "authType": {
+                        "$comment": "Required for certain consumers: F5_Cloud",
+                        "title": "SA Type",
+                        "description": "" ,
+                        "type": "string",
+                        "enum": ["google-auth" ]
+                    },
+                    "type": {
+                        "$comment": "Required for certain consumers: F5_Cloud",
+                        "title": "SA Type",
+                        "description": "" ,
+                        "type": "string",
+                        "minLength": 1,
+                        "f5expand": true
+                    },
+                    "projectId": {
+                        "$comment": "Required for certain consumers: F5_Cloud",
+                        "title": "Project Id",
+                        "description": "" ,
+                        "type": "string",
+                        "minLength": 1,
+                        "f5expand": true
+                    },
+                    "privateKeyId": {
+                        "$comment": "Required for certain consumers: F5_Cloud",
+                        "title": "Private Key Id",
+                        "description": "" ,
+                        "type": "string",
+                        "minLength": 1,
+                        "f5expand": true
+                    },
+                    "privateKey": {
+                        "$ref": "base_schema.json#/definitions/secret"
+                    },
+                    "clientEmail": {
+                        "$comment": "Required for certain consumers: F5_Cloud",
+                        "title": "Client Email",
+                        "description": "" ,
+                        "type": "string",
+                        "minLength": 1,
+                        "f5expand": true
+                    },
+                    "clientId": {
+                        "$comment": "Required for certain consumers: F5_Cloud",
+                        "title": "Client Id",
+                        "description": "" ,
+                        "type": "string",
+                        "minLength": 1,
+                        "f5expand": true
+                    },
+                    "authUri": {
+                        "$comment": "Required for certain consumers: F5_Cloud",
+                        "title": "Auth Uri",
+                        "description": "" ,
+                        "type": "string",
+                        "minLength": 1,
+                        "f5expand": true
+                    },
+                    "tokenUri": {
+                        "$comment": "Required for certain consumers: F5_Cloud",
+                        "title": "Token Uri",
+                        "description": "" ,
+                        "type": "string",
+                        "minLength": 1,
+                        "f5expand": true
+                    },
+                    "authProviderX509CertUrl": {
+                        "$comment": "Required for certain consumers: F5_Cloud",
+                        "title": "Auth Provider X509 Cert Url",
+                        "description": "" ,
+                        "type": "string",
+                        "minLength": 1,
+                        "f5expand": true
+                    },
+                    "clientX509CertUrl": {
+                        "$comment": "Required for certain consumers: F5_Cloud",
+                        "title": "Client X509 Cert Url",
+                        "description": "" ,
+                        "type": "string",
+                        "minLength": 1,
+                        "f5expand": true
+                    }
+                },
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "if": { "properties": { "authType": { "const": "google-auth" } } },
+                    "then": {
+                        "required": [
+                            "type",
+                            "projectId",
+                            "privateKeyId",
+                            "privateKey",
+                            "clientEmail",
+                            "clientId",
+                            "authUri",
+                            "tokenUri",
+                            "authProviderX509CertUrl",
+                            "clientX509CertUrl"
+                        ]
+                    },
+                    "else": {}
+                }]
+        },
+        "targetAudience": {
+            "$comment": "Required for certain consumers: F5_Cloud",
+            "title": "Target Audience",
+            "description": "" ,
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "useSSL": {
+            "$comment": "Required for certain consumers: F5_Cloud",
+            "title": "useSSL",
+            "description": "To decide if GRPC connection should use SSL and then it is secured" ,
+            "type": "boolean",
+            "f5expand": true
+        },
+        "compressionType": {
+            "$comment": "Required for certain consumers: DataDog, Splunk",
+            "title": "Data compression",
+            "description": "Whether or not to compress data and what compression to use before sending it to destination",
+            "type": "string",
+            "enum": ["none", "gzip"]
+        },
+        "reportInstanceMetadata": {
+            "$comment": "Required for certain consumers: Google_Cloud_Monitoring, Google_Cloud_Logging",
+            "title": "Instance metadata reporting",
+            "description": "Enables instance metadata collection and reporting" ,
+            "type": "boolean",
+            "f5expand": true
+        },
+        "apiKey": {
+            "$comment": "Required for certain consumers: DataDog",
+            "title": "API key to use to push data",
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "service": {
+            "$comment": "Required for certain consumers: DataDog",
+            "title": "The name of the service generating telemetry data",
+            "type": "string",
+            "minLength": 1,
+            "f5expand": true
+        },
+        "convertBooleansToMetrics": {
+            "$comment": "Required for certain consumers: DataDog, Statsd, OpenTelemetry_Exporter",
+            "title": "Convert boolean values to metrics",
+            "description": "Whether or not to convert boolean values to metrics. True becomes 1, False becomes 0" ,
+            "type": "boolean",
+            "f5expand": true,
+            "default": false
+        },
+        "customTags": {
+            "$comment": "Required for certain consumers: DataDog",
+            "title": "Custom tags",
+            "description": "A collection of custom tags that are appended to the dynamically generated telemetry tags",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "properties": {
+                    "name": {
+                        "description": "Name of this tag",
+                        "type": "string",
+                        "f5expand": true,
+                        "minLength": 1
+                    },
+                    "value": {
+                        "description": "Value of this tag",
+                        "type": "string",
+                        "f5expand": true,
+                        "minLength": 1
+                    }
+                },
+                "additionalProperties": false
+            }
+        }
+    },
+    "allOf": [
+        {
+            "if": { "properties": { "class": { "const": "Telemetry_Consumer" } } },
+            "then": {
+                "required": [
+                    "class",
+                    "type"
+                ],
+                "properties": {
+                    "class": {
+                        "title": "Class",
+                        "description": "Telemetry Streaming Consumer class",
+                        "type": "string",
+                        "enum": [ "Telemetry_Consumer" ]
+                    },
+                    "enable": {
+                        "default": true,
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/enable"
+                            }
+                        ]
+                    },
+                    "trace": {
+                        "default": false,
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/trace"
+                            }
+                        ]
+                    },
+                    "type": {
+                        "title": "Type",
+                        "description": "" ,
+                        "type": "string",
+                        "enum": [
+                            "AWS_CloudWatch",
+                            "AWS_S3",
+                            "Azure_Log_Analytics",
+                            "Azure_Application_Insights",
+                            "DataDog",
+                            "default",
+                            "ElasticSearch",
+                            "Generic_HTTP",
+                            "Google_Cloud_Logging",
+                            "Google_Cloud_Monitoring",
+                            "Google_StackDriver",
+                            "Graphite",
+                            "Kafka",
+                            "OpenTelemetry_Exporter",
+                            "Splunk",
+                            "Statsd",
+                            "Sumo_Logic",
+                            "F5_Cloud"
+                        ]
+                    },
+                    "enableHostConnectivityCheck": {
+                        "$ref": "base_schema.json#/definitions/enableHostConnectivityCheck"
+                    },
+                    "allowSelfSignedCert": {
+                        "default": false,
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/allowSelfSignedCert"
+                            }
+                        ]
+                    }
+                },
+                "allOf": [
+                    {
+                        "$comment": "This allows enforcement of no additional properties in this nested schema - could reuse above properties but prefer a separate block",
+                        "properties": {
+                            "addTags": {},
+                            "actions": {},
+                            "apiKey": {},
+                            "class": {},
+                            "customTags": {},
+                            "enable": {},
+                            "trace": {},
+                            "type": {},
+                            "enableHostConnectivityCheck": {},
+                            "allowSelfSignedCert": {},
+                            "host": {},
+                            "protocol": {},
+                            "port": {},
+                            "path": {},
+                            "method": {},
+                            "headers": {},
+                            "customOpts": {},
+                            "username": {},
+                            "passphrase": {},
+                            "format": {},
+                            "workspaceId": {},
+                            "useManagedIdentity": {},
+                            "instrumentationKey": {},
+                            "appInsightsResourceName": {},
+                            "maxBatchIntervalMs": {},
+                            "maxBatchSize": {},
+                            "region": {},
+                            "endpointUrl": {},
+                            "maxAwsLogBatchSize": {},
+                            "logGroup": {},
+                            "logStream": {},
+                            "metricNamespace": {},
+                            "metricPrefix": {},
+                            "bucket": {},
+                            "topic": {},
+                            "apiVersion": {},
+                            "index": {},
+                            "dataType": {},
+                            "authenticationProtocol": {},
+                            "projectId": {},
+                            "serviceEmail": {},
+                            "privateKey": {},
+                            "privateKeyId": {},
+                            "useServiceAccountToken": {},
+                            "clientCertificate": {},
+                            "rootCertificate": {},
+                            "outputMode": {},
+                            "fallbackHosts": {},
+                            "eventSchemaVersion": {},
+                            "f5csTenantId": {},
+                            "f5csSensorId": {},
+                            "payloadSchemaNid": {},
+                            "serviceAccount": {},
+                            "targetAudience": {},
+                            "useSSL": {},
+                            "proxy": {},
+                            "compressionType": {},
+                            "logScope": {},
+                            "logScopeId": {},
+                            "logId": {},
+                            "reportInstanceMetadata": {},
+                            "metricsPath": {},
+                            "service": {},
+                            "convertBooleansToMetrics": {}
+                        },
+                        "additionalProperties": false,
+                        "dependencies": {
+                            "actions": {
+                                "allOf": [
+                                    {
+                                        "properties": { "type": { "const": "Generic_HTTP" } }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "default" } } },
+                        "then": {
+                            "required": [],
+                            "properties": {}
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "Generic_HTTP" } } },
+                        "then": {
+                            "required": [
+                                "host"
+                            ],
+                            "properties": {
+                                "host": { "$ref": "#/definitions/host" },
+                                "fallbackHosts": {
+                                    "type": "array",
+                                    "description": "List FQDNs or IP addresses to be used as fallback hosts" ,
+                                    "minItems": 1,
+                                    "items": {
+                                        "allOf": [{
+                                            "$ref": "#/definitions/host"
+                                        }]
+                                    }
+                                },
+                                "protocol": { "$ref": "#/definitions/protocols", "default": "https" },
+                                "port": { "$ref": "#/definitions/port", "default": 443 },
+                                "path": { "$ref": "#/definitions/path", "default": "/" },
+                                "method": { "$ref": "#/definitions/method", "default": "POST" },
+                                "headers": { "$ref": "#/definitions/headers" },
+                                "passphrase": { "$ref": "base_schema.json#/definitions/secret" },
+                                "proxy": { "$ref": "base_schema.json#/definitions/proxy" },
+                                "privateKey": { "$ref": "#/definitions/privateKey" },
+                                "clientCertificate": { "$ref": "#/definitions/clientCertificate" },
+                                "rootCertificate": { "$ref": "#/definitions/rootCertificate" },
+                                "outputMode": { "$ref": "#/definitions/outputMode", "default": "processed" },
+                                "actions": { "$ref": "#/definitions/genericHttpActions" }
+                            },
+                            "allOf": [
+                                {
+                                    "if": { "required": [ "clientCertificate" ] },
+                                    "then": { "required": [ "privateKey" ] }
+                                },
+                                {
+                                    "if": { "required": [ "privateKey" ] },
+                                    "then": { "required": [ "clientCertificate" ] }
+                                }
+                            ]
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "Splunk" } } },
+                        "then": {
+                            "required": [
+                                "host",
+                                "passphrase"
+                            ],
+                            "properties": {
+                                "host": { "$ref": "#/definitions/host" },
+                                "protocol": { "$ref": "#/definitions/protocols", "default": "https" },
+                                "port": { "$ref": "#/definitions/port", "default": 8088 },
+                                "passphrase": { "$ref": "base_schema.json#/definitions/secret" },
+                                "format": { "$ref": "#/definitions/format", "enum": [ "default", "legacy", "multiMetric" ], "default": "default" },
+                                "proxy": { "$ref": "base_schema.json#/definitions/proxy" },
+                                "compressionType": { "$ref": "#/definitions/compressionType", "default": "gzip" }
+                            }
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "Azure_Log_Analytics" } } },
+                        "then": {
+                            "required": [
+                                "workspaceId"
+                            ],
+                            "properties": {
+                                "workspaceId": { "$ref": "#/definitions/workspaceId" },
+                                "format": { "$ref": "#/definitions/format", "enum": [ "default", "propertyBased" ], "default": "default" },
+                                "passphrase": { "$ref": "base_schema.json#/definitions/secret" },
+                                "customOpts": { "$ref": "#/definitions/customOpts" },
+                                "useManagedIdentity": { "$ref": "#/definitions/useManagedIdentity", "default": false },
+                                "region": { "$ref": "#/definitions/region" }
+                            },
+                            "allOf": [
+                                {
+                                    "dependencies": {
+                                        "passphrase": {
+                                            "anyOf": [
+                                                { "not": {"required": [ "useManagedIdentity" ] } },
+                                                { "properties": { "useManagedIdentity": { "const": false } } }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "if": { "not": { "required" : [ "useManagedIdentity"] } },
+                                    "then": { "required": ["passphrase"] },
+                                    "else": {
+                                            "if": { "properties": { "useManagedIdentity": { "const": true } } },
+                                            "then": { "not": { "required": ["passphrase"] } },
+                                            "else": { "required": ["passphrase"]}
+                                    }
+                                }
+                            ]
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "Azure_Application_Insights" } } },
+                        "then": {
+                            "properties": {
+                                "instrumentationKey": { "$ref": "#/definitions/instrumentationKey" },
+                                "maxBatchSize": { "$ref": "#/definitions/maxBatchSize", "default": 250 },
+                                "maxBatchIntervalMs": { "$ref": "#/definitions/maxBatchIntervalMs", "default": 5000 },
+                                "customOpts": { "$ref": "#/definitions/customOpts" },
+                                "useManagedIdentity": { "$ref": "#/definitions/useManagedIdentity", "default": false },
+                                "appInsightsResourceName": { "$ref": "#/definitions/appInsightsResourceName" },
+                                "region": { "$ref": "#/definitions/region" }
+                            },
+                            "allOf": [
+                                {
+                                    "dependencies": {
+                                        "instrumentationKey": {
+                                            "allOf": [
+                                                {
+                                                    "anyOf": [
+                                                        { "not": { "required": [ "useManagedIdentity" ] } },
+                                                        { "properties": { "useManagedIdentity": { "const": false } } }
+                                                    ]
+                                                },
+                                                {
+                                                    "not": { "required": ["appInsightsResourceName"] }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "if": { "not": { "required" : [ "useManagedIdentity"] } },
+                                    "then": { "required": ["instrumentationKey"] },
+                                    "else": {
+                                            "if": { "properties": { "useManagedIdentity": { "const": true } } },
+                                            "then": { "not": { "required": ["instrumentationKey"] } },
+                                            "else": {
+                                                "allOf": [
+                                                    { "required": [ "instrumentationKey" ]},
+                                                    { "not": { "required": [ "appInsightsResourceName" ] } }
+                                                ]
+                                            }
+                                    }
+                                },
+                                {
+                                    "if": { "required": [ "appInsightsResourceName" ] },
+                                    "then": { "properties": { "appInsightsResourceName": { "minLength": 1 } }}
+                                }
+                            ]
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "AWS_CloudWatch" } } },
+                        "then": {
+                            "required": [
+                                "region",
+                                "dataType"
+                            ],
+                            "properties": {
+                                "region": { "$ref": "#/definitions/region" },
+                                "dataType": { "$ref": "#/definitions/dataType", "default": "logs" },
+                                "username": { "$ref": "#/definitions/username" },
+                                "passphrase": { "$ref": "base_schema.json#/definitions/secret" },
+                                "endpointUrl": { "$ref": "#/definitions/endpointUrl" }
+                            },
+                            "allOf": [
+                                { "not": { "required": ["username"], "not": { "required": ["passphrase"] }}},
+                                { "not": { "required": ["passphrase"], "not": { "required": ["username"] }}},
+                                {
+                                    "if": { "properties": { "dataType": { "enum": ["logs", null] } } },
+                                    "then": {
+                                        "properties": {
+                                            "maxAwsLogBatchSize": { "$ref": "#/definitions/maxAwsLogBatchSize", "default": 100 }
+                                        },
+                                        "required": ["maxAwsLogBatchSize"]
+                                    }
+                                },
+                                { "oneOf":
+                                    [
+                                        {
+                                            "allOf": [
+                                                {
+                                                    "properties": {
+                                                        "logGroup": { "$ref": "#/definitions/logGroup" },
+                                                        "logStream": { "$ref": "#/definitions/logStream" },
+                                                        "dataType": {
+                                                            "allOf":
+                                                            [
+                                                                { "$ref": "#/definitions/dataType"},
+                                                                { "enum": ["logs", null] }
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                { "required":[ "logGroup", "logStream" ] },
+                                                { "not": { "required": ["metricNamespace"] }}
+                                            ]
+                                        },
+                                        {
+                                            "allOf": [
+                                                {
+                                                    "properties": {
+                                                        "metricNamespace": { "$ref": "#/definitions/metricNamespace" },
+                                                        "dataType": {
+                                                            "allOf": [
+                                                                { "$ref": "#/definitions/dataType"},
+                                                                { "enum": ["metrics"] }
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                { "required":[ "metricNamespace" ] },
+                                                { "not": { "required":[ "maxAwsLogBatchSize" ] }},
+                                                { "not": { "required":[ "logStream" ] }},
+                                                { "not": { "required":[ "logGroup" ] }}
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "AWS_S3" } } },
+                        "then": {
+                            "required": [
+                                "region",
+                                "bucket"
+                            ],
+                            "properties": {
+                                "region": { "$ref": "#/definitions/region" },
+                                "bucket": { "$ref": "#/definitions/bucket" },
+                                "username": { "$ref": "#/definitions/username" },
+                                "passphrase": { "$ref": "base_schema.json#/definitions/secret" },
+                                "endpointUrl": { "$ref": "#/definitions/endpointUrl" }
+                            },
+                            "dependencies": {
+                                "passphrase": [ "username" ],
+                                "username":[ "passphrase" ]
+                            }
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "Graphite" } } },
+                        "then": {
+                            "required": [
+                                "host"
+                            ],
+                            "properties": {
+                                "host": { "$ref": "#/definitions/host" },
+                                "protocol": { "$ref": "#/definitions/protocols", "default": "https" },
+                                "port": { "$ref": "#/definitions/port", "default": 443 },
+                                "path": { "$ref": "#/definitions/path", "default": "/events/" }
+                            }
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "Kafka" } } },
+                        "then": {
+                            "required": [
+                                "host",
+                                "topic"
+                            ],
+                            "properties": {
+                                "authenticationProtocol": { "$ref": "#/definitions/authenticationProtocol", "default": "None" },
+                                "host": { "$ref": "#/definitions/host" },
+                                "protocol": { "$ref": "#/definitions/protocols", "default": "binaryTcpTls" },
+                                "port": { "$ref": "#/definitions/port", "default": 9092 },
+                                "topic": { "$ref": "#/definitions/topic" } 
+                            },
+                            "allOf": [
+                                {
+                                    "if": { "properties": { "authenticationProtocol": { "const": "SASL-PLAIN" } } },
+                                    "then": {
+                                        "required": [
+                                            "username"
+                                        ],
+                                        "properties": {
+                                            "username": { "$ref": "#/definitions/username" },
+                                            "passphrase": { "$ref": "base_schema.json#/definitions/secret" }
+                                        },
+                                        "dependencies": {
+                                            "passphrase": [ "username" ]
+                                        }
+                                    },
+                                    "else": {}
+                                },
+                                {
+                                    "if": { "properties": { "authenticationProtocol": { "const": "TLS" } } },
+                                    "then": {
+                                        "required": [
+                                            "privateKey",
+                                            "clientCertificate"
+                                        ],
+                                        "allOf": [
+                                            { "not": { "required": [ "username" ] } },
+                                            { "not": { "required": [ "passphrase" ] } }
+                                        ],
+                                        "properties": {
+                                            "privateKey": { "$ref": "#/definitions/privateKey" },
+                                            "clientCertificate": { "$ref": "#/definitions/clientCertificate" },
+                                            "rootCertificate": { "$ref": "#/definitions/rootCertificate" },
+                                            "protocol": { "const": "binaryTcpTls" }
+                                        }
+                                    },
+                                    "else": {}
+                                }
+                            ]
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "ElasticSearch" } } },
+                        "then": {
+                            "required": [
+                                "host",
+                                "index"
+                            ],
+                            "properties": {
+                                "host": { "$ref": "#/definitions/host" },
+                                "protocol": { "$ref": "#/definitions/protocols", "default": "https" },
+                                "port": { "$ref": "#/definitions/port", "default": 9200 },
+                                "path": { "$ref": "#/definitions/path" },
+                                "username": { "$ref": "#/definitions/username" },
+                                "passphrase": { "$ref": "base_schema.json#/definitions/secret" },
+                                "apiVersion": { "$ref": "#/definitions/apiVersion", "default": "6.0" },
+                                "index": { "$ref": "#/definitions/index" }
+                            },
+                            "allOf": [
+                                {
+                                    "if": { "properties": { "apiVersion": { "pattern": "^[0-6][.]|^[0-6]$" } } },
+                                    "then": {
+                                        "properties": {
+                                            "dataType": {
+                                                "$ref": "#/definitions/dataType",
+                                                "default": "f5.telemetry",
+                                                "minLength": 1
+                                            }
+                                        }
+                                    },
+                                    "else": {
+                                        "if": { "properties": { "apiVersion": { "pattern": "^7[.]|^7$" } } },
+                                        "then": {
+                                            "properties": {
+                                                "dataType": {
+                                                    "$ref": "#/definitions/dataType",
+                                                    "default": "_doc",
+                                                    "minLength": 1
+                                                }
+                                            }
+                                        },
+                                        "else": {
+                                            "allOf": [
+                                                { "not": { "required": [ "dataType" ] } }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "Sumo_Logic" } } },
+                        "then": {
+                            "required": [
+                                "host",
+                                "passphrase"
+                            ],
+                            "properties": {
+                                "host": { "$ref": "#/definitions/host" },
+                                "protocol": { "$ref": "#/definitions/protocols", "default": "https" },
+                                "port": { "$ref": "#/definitions/port", "default": 443 },
+                                "path": { "$ref": "#/definitions/path", "default": "/receiver/v1/http/" },
+                                "passphrase": { "$ref": "base_schema.json#/definitions/secret" }
+                            }
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "Statsd" } } },
+                        "then": {
+                            "required": [
+                                "host"
+                            ],
+                            "properties": {
+                                "host": { "$ref": "#/definitions/host" },
+                                "protocol": {
+                                    "title": "Protocol",
+                                    "type": "string",
+                                    "enum": [ "tcp", "udp" ],
+                                    "default": "udp"
+                                },
+                                "port": { "$ref": "#/definitions/port", "default": 8125 },
+                                "addTags": { "$ref": "#/definitions/autoTaggingStatsd" },
+                                "convertBooleansToMetrics": { "$ref": "#/definitions/convertBooleansToMetrics", "default": "false" }
+                            }
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": {
+                            "properties": { "type": { "enum": ["Google_Cloud_Monitoring", "Google_StackDriver", "Google_Cloud_Logging"] } }
+                        },
+                        "then": {
+                            "required": [
+                                "serviceEmail"
+                            ],
+                            "properties": {
+                                "privateKeyId": { "$ref": "#/definitions/privateKeyId" },
+                                "serviceEmail": { "$ref": "#/definitions/serviceEmail" },
+                                "privateKey": { "$ref": "base_schema.json#/definitions/secret" },
+                                "useServiceAccountToken": { "$ref": "#/definitions/useServiceAccountToken", "default": false },
+                                "reportInstanceMetadata": { "$ref": "#/definitions/reportInstanceMetadata", "default": false }
+                            },
+                            "allOf": [
+                                {
+                                    "dependencies": {
+                                        "privateKeyId": {
+                                            "anyOf": [
+                                                { "not": {"required": [ "useServiceAccountToken" ] } },
+                                                { "properties": { "useServiceAccountToken": { "const": false } } }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "dependencies": {
+                                        "privateKey": {
+                                            "anyOf": [
+                                                { "not": {"required": [ "useServiceAccountToken" ] } },
+                                                { "properties": { "useServiceAccountToken": { "const": false } } }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "anyOf": [
+                                            { "not": { "required" : [ "useServiceAccountToken"] } },
+                                            { "properties": { "useServiceAccountToken": { "const": false } } }
+                                        ]
+                                    },
+                                    "then": { "required": ["privateKeyId", "privateKey"] },
+                                    "else": { "not": { "required": ["privateKeyId", "privateKey"] } }
+                                },
+                                {
+                                    "if": { "properties": { "type": { "enum": ["Google_Cloud_Monitoring", "Google_StackDriver"] } } },
+                                    "then": {
+                                        "properties": {
+                                            "projectId": { "$ref": "#/definitions/projectId"}
+                                        },
+                                        "required": ["projectId"]
+                                    }
+                                },
+                                {
+                                    "if": { "properties": { "type": { "const": "Google_Cloud_Logging" } } },
+                                    "then": {
+                                        "properties": {
+                                            "logScope": { "$ref": "#/definitions/logScope", "default": "projects" },
+                                            "logScopeId": { "$ref": "#/definitions/logScopeId"},
+                                            "logId": { "$ref": "#/definitions/logId"}
+                                        },
+                                        "required": ["logScope", "logScopeId", "logId"]
+                                    }
+                                }
+                            ]
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "F5_Cloud" } } },
+                        "then": {
+                            "required": [
+                                "f5csTenantId",
+                                "f5csSensorId",
+                                "payloadSchemaNid",
+                                "serviceAccount",
+                                "targetAudience"
+                            ],
+                            "properties": {
+                                "port": { "$ref": "#/definitions/port", "default": 443 },
+                                "eventSchemaVersion": { "$ref": "#/definitions/eventSchemaVersion" },
+                                "f5csTenantId": { "$ref": "#/definitions/f5csTenantId" },
+                                "f5csSensorId": { "$ref": "#/definitions/f5csSensorId" },
+                                "payloadSchemaNid": { "$ref": "#/definitions/payloadSchemaNid" },
+                                "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+                                "targetAudience": { "$ref": "#/definitions/targetAudience" },
+                                "useSSL": { "$ref": "#/definitions/useSSL", "default": true }
+                            },
+                            "nodeSupportVersion": "8.11.1"
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "DataDog" } } },
+                        "then": {
+                            "required": [
+                                "apiKey"
+                            ],
+                            "properties": {
+                                "apiKey": { "$ref": "#/definitions/apiKey" },
+                                "compressionType": { "$ref": "#/definitions/compressionType", "default": "none" },
+                                "region": { "$ref": "#/definitions/region", "enum": ["US1", "US3", "EU1", "US1-FED"], "default": "US1" },
+                                "service": { "$ref": "#/definitions/service", "default": "f5-telemetry" },
+                                "metricPrefix": { "$ref": "#/definitions/metricPrefix" },
+                                "convertBooleansToMetrics": { "$ref": "#/definitions/convertBooleansToMetrics", "default": "false" },
+                                "customTags": { "$ref": "#/definitions/customTags" }
+                            }
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "OpenTelemetry_Exporter" } } },
+                        "then": {
+                            "required": [
+                                "host",
+                                "port"
+                            ],
+                            "properties": {
+                                "host": { "$ref": "#/definitions/host" },
+                                "port": { "$ref": "#/definitions/port" },
+                                "headers": { "$ref": "#/definitions/headers" },
+                                "metricsPath": { "$ref": "#/definitions/path" },
+                                "convertBooleansToMetrics": { "$ref": "#/definitions/convertBooleansToMetrics", "default": "false" }
+                            },
+                            "nodeSupportVersion": "8.11.1"
+                        },
+                        "else": {}
+                    }
+                ]
+            },
+            "else": {}
+        }
+    ]
+}

--- a/src/schema/1.31.0/controls_schema.json
+++ b/src/schema/1.31.0/controls_schema.json
@@ -1,0 +1,52 @@
+{
+    "$id": "controls_schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry Streaming Controls schema",
+    "description": "",
+    "type": "object",
+    "allOf": [
+        {
+            "if": { "properties": { "class": { "const": "Controls" } } },
+            "then": {
+                "required": [
+                    "class"
+                ],
+                "properties": {
+                    "class": {
+                        "title": "Class",
+                        "description": "Telemetry Streaming Controls class",
+                        "type": "string",
+                        "enum": [ "Controls" ]
+                    },
+                    "logLevel": {
+                        "title": "Logging Level",
+                        "description": "",
+                        "type": "string",
+                        "default": "info",
+                        "enum": [ 
+                            "debug",
+                            "info",
+                            "error"
+                        ] 
+                    },
+                    "debug": {
+                        "title": "Enable debug mode",
+                        "description": "",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "memoryThresholdPercent": {
+                        "title": "Memory Usage Threshold (Percentage of Available Process Memory)",
+                        "description": "Once memory usage reaches this value, processing may temporarily cease until levels return below threshold. Defaults to 90%",
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "default": 90
+                    }
+                },
+                "additionalProperties": false
+            },
+            "else": {}
+        }
+    ]
+}

--- a/src/schema/1.31.0/endpoints_schema.json
+++ b/src/schema/1.31.0/endpoints_schema.json
@@ -1,0 +1,190 @@
+{
+    "$id": "endpoints_schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry Streaming Endpoints schema",
+    "description": "",
+    "type": "object",
+    "definitions": {
+        "endpoint": {
+            "title": "Telemetry Endpoint",
+            "description": "",
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "title": "Enable endpoint",
+                    "default": true,
+                    "allOf": [
+                        {
+                            "$ref": "base_schema.json#/definitions/enable"
+                        }
+                    ]
+                },
+                "name": {
+                    "title": "Endpoint name",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "numericalEnums": {
+                    "title": "SNMP Options: print enums numerically",
+                    "type": "boolean"
+                },
+                "path": {
+                    "title": "Path to query data from",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "protocol": {
+                    "title": "Endpoint protocol used to fetch data",
+                    "type": "string",
+                    "enum": ["http", "snmp"],
+                    "default": "http"
+                }
+            },
+            "allOf": [
+                {
+                    "if": { "properties": { "protocol": { "const": "snmp" } } },
+                    "then": {
+                        "properties": {
+                            "numericalEnums": {
+                                "default": false
+                            },
+                            "path": {
+                                "pattern": "^[a-zA-Z0-9.]+$"
+                            }
+                        }
+                    },
+                    "else": {
+                        "not": {
+                            "required": ["numericalEnums"]
+                        }
+                    }
+                }
+            ],
+            "additionalProperties": false
+        },
+        "endpoints": {
+            "title": "Telemetry Endpoints",
+            "description": "",
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "title": "Enable endpoints",
+                    "default": true,
+                    "allOf": [
+                        {
+                            "$ref": "base_schema.json#/definitions/enable"
+                        }
+                    ]
+                },
+                "basePath": {
+                    "title": "Base Path",
+                    "description": "Optional base path value to prepend to each individual endpoint paths",
+                    "type": "string",
+                    "default": ""
+                },
+                "items": {
+                    "title": "Items",
+                    "description": "Object with each property an endpoint with their own properties",
+                    "type": "object",
+                    "additionalProperties": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/endpoint"
+                            },
+                            { 
+                                "required": [ "path"]
+                            }
+                        ]
+                    },
+                    "minProperties": 1
+                }
+            }
+        },
+        "endpointsObjectRef": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/endpoints"
+                },
+                {
+                    "properties": {
+                        "enable": {},
+                        "basePath": {},
+                        "items": {}
+                    },
+                    "required": [ "items" ],
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "endpointObjectRef": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/endpoint"
+                },
+                {
+                    "properties": {
+                        "enable": {},
+                        "name": {},
+                        "numericalEnums": {},
+                        "path": {},
+                        "protocol": {}
+                    },
+                    "required": [ "name", "path" ],
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "endpointsPointerRef": {
+            "title": "Telemetry_Endpoints Name",
+            "description": "Name of the Telemetry_Endpoints object",
+            "type": "string",
+            "declarationClass": "Telemetry_Endpoints",
+            "minLength": 1
+        },
+        "endpointsItemPointerRef": {
+            "title": "Telemetry_Endpoints Name and Item Key",
+            "description": "Name of the Telemetry_Endpoints object and the endpoint item key, e.g endpointsA/item1",
+            "type": "string",
+            "declarationClassProp": {
+                "path" :"Telemetry_Endpoints/items",
+                "partsNum": 2
+            },
+            "minLength": 1
+        }
+    },
+    "allOf": [
+        {
+            "if": { "properties": { "class": { "const": "Telemetry_Endpoints" } } },
+            "then": {
+                "required": [
+                    "class",
+                    "items"
+                ],
+                "properties": {
+                    "class": {
+                        "title": "Class",
+                        "description": "Telemetry Streaming Endpoints class",
+                        "type": "string",
+                        "enum": [ "Telemetry_Endpoints" ]
+                    }
+                },
+                "allOf": [
+                    {
+                        "$comment": "This allows enforcement of no additional properties in this nested schema - could reuse above properties but prefer a separate block",
+                        "properties": {
+                            "class": {},
+                            "enable": {},
+                            "basePath": {},
+                            "items": {}
+                        },
+                        "additionalProperties": false
+                    },
+                    {
+                        "$ref": "#/definitions/endpoints"
+                    }
+                ]
+            },
+            "else": {}
+        }
+    ]
+}

--- a/src/schema/1.31.0/ihealth_poller_schema.json
+++ b/src/schema/1.31.0/ihealth_poller_schema.json
@@ -1,0 +1,238 @@
+{
+    "$id": "ihealth_poller_schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry Streaming iHealth Poller schema",
+    "description": "",
+    "type": "object",
+    "definitions": {
+        "time24hr": {
+            "title": "Time in HH:MM, 24hr",
+            "description": "",
+            "type": "string",
+            "pattern": "^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]?$"
+        },
+        "iHealthPoller": {
+            "$comment": "system_schema.json should be updated when new property added",
+            "title": "iHealth Poller",
+            "description": "",
+            "type": "object",
+            "required": [
+                "interval",
+                "username",
+                "passphrase"
+            ],
+            "properties": {
+                "enable": {
+                    "default": true,
+                    "allOf": [
+                        {
+                            "$ref": "base_schema.json#/definitions/enable"
+                        }
+                    ]
+                },
+                "trace": {
+                    "default": false,
+                    "allOf": [
+                        {
+                            "$ref": "base_schema.json#/definitions/trace"
+                        }
+                    ]
+                },
+                "proxy": { 
+                    "title": "Proxy configuration",
+                    "properties": {
+                        "port": {
+                            "default": 80
+                        },
+                        "protocol": {
+                            "default": "http"
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "$ref": "base_schema.json#/definitions/proxy"
+                        }
+                    ]
+                },
+                "username": {
+                    "title": "iHealth Username",
+                    "$ref": "base_schema.json#/definitions/username"
+                },
+                "passphrase": {
+                    "title": "iHealth Passphrase",
+                    "$ref": "base_schema.json#/definitions/secret"
+                },
+                "downloadFolder": {
+                    "title": "Directory to download Qkview to",
+                    "description": "",
+                    "type": "string",
+                    "minLength": 1,
+                    "pathExists": true
+                },
+                "interval": {
+                    "title": "Operating interval",
+                    "description": "" ,
+                    "type": "object",
+                    "properties": {
+                        "timeWindow": {
+                            "title": "Two or more hours window in 24hr format that iHealth data can be sent",
+                            "description": "",
+                            "type": "object",
+                            "properties": {
+                                "start": {
+                                    "title": "Time when the window starts",
+                                    "$ref": "#/definitions/time24hr"
+                                },
+                                "end": { 
+                                    "title": "Time when the window ends",
+                                    "$ref": "#/definitions/time24hr"
+                                }
+                            },
+                            "timeWindowMinSize": 120,
+                            "required": [ "start", "end" ],
+                            "additionalProperties": false
+                        },
+                        "frequency": {
+                            "title": "Interval frequency",
+                            "description": "",
+                            "type": "string",
+                            "default": "daily",
+                            "enum": [
+                                "daily",
+                                "weekly",
+                                "monthly"
+                            ]
+                        }
+
+                    },
+                    "required": [
+                        "timeWindow"
+                    ],
+                    "allOf": [
+                        { 
+                            "if": { "properties": { "frequency": { "const": "daily" } } },
+                            "then": {
+                                "properties": {
+                                    "timeWindow": {},
+                                    "frequency": {}
+                                },
+                                "additionalProperties": false
+                            }
+                        },
+                        {
+                            "if": { "properties": { "frequency": { "const": "weekly" } } },
+                            "then": {
+                                "properties": {
+                                    "timeWindow": {},
+                                    "frequency": {},
+                                    "day": {
+                                        "title": "",
+                                        "description": "",
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "pattern": "^([mM]onday|[tT]uesday|[wW]ednesday|[tT]hursday|[fF]riday|[sS]aturday|[sS]unday)$"
+                                            },
+                                            {
+                                                "$comment": "0 and 7 eq. Sunday",
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "maximum": 7
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": [ "day" ],
+                                "additionalProperties": false
+                            }
+                        },
+                        {
+                            "if": { "properties": { "frequency": { "const": "monthly" } } },
+                            "then": {
+                                "properties": {
+                                    "timeWindow": {},
+                                    "frequency": {},
+                                    "day": {
+                                        "title": "",
+                                        "description": "",
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 31
+                                    }
+                                },
+                                "required": [ "day" ],
+                                "additionalProperties": false
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "iHealthPollerPointerRef": {
+            "type": "string",
+            "minLength": 1,
+            "declarationClass": "Telemetry_iHealth_Poller"
+        },
+        "iHealthPollerObjectRef": {
+            "allOf": [
+                {
+                    "$comment": "This allows enforcement of no additional properties in this nested schema - could reuse above properties but prefer a separate block",
+                    "properties": {
+                        "enable": {},
+                        "trace": {},
+                        "interval": {},
+                        "proxy": {},
+                        "username": {},
+                        "passphrase": {},
+                        "downloadFolder": {}
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "$ref": "ihealth_poller_schema.json#/definitions/iHealthPoller"
+                }
+            ]
+        }
+    },
+    "allOf": [
+        {
+            "if": { "properties": { "class": { "const": "Telemetry_iHealth_Poller" } } },
+            "then": {
+                "required": [
+                    "class",
+                    "username",
+                    "passphrase"
+                ],
+                "properties": {
+                    "class": {
+                        "title": "Class",
+                        "description": "Telemetry Streaming iHealth Poller class",
+                        "type": "string",
+                        "enum": [ "Telemetry_iHealth_Poller" ]
+                    }
+                },
+                "allOf": [
+                    {
+                        "$comment": "This allows enforcement of no additional properties in this nested schema - could reuse above properties but prefer a separate block",
+                        "properties": {
+                            "class": {},
+                            "enable": {},
+                            "trace": {},
+                            "interval": {},
+                            "proxy": {},
+                            "username": {},
+                            "passphrase": {},
+                            "downloadFolder": {}
+                        },
+                        "additionalProperties": false
+                    },
+                    {
+                        "$ref": "#/definitions/iHealthPoller"
+                    }
+                ]
+            },
+            "else": {},
+            "$comment": "Telemetry_iHealth_Poller should be either built-in within Telemetry_System or referenced by Telemetry_System(s), otherwise it will be treated as disabled"
+        }
+    ]
+}

--- a/src/schema/1.31.0/listener_schema.json
+++ b/src/schema/1.31.0/listener_schema.json
@@ -1,0 +1,85 @@
+{
+    "$id": "listener_schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry Streaming event listener schema",
+    "description": "",
+    "type": "object",
+    "allOf": [
+        {
+            "if": { "properties": { "class": { "const": "Telemetry_Listener" } } },
+            "then": {
+                "required": [
+                    "class"
+                ],
+                "properties": {
+                    "class": {
+                        "title": "Class",
+                        "description": "Telemetry Streaming Event Listener class",
+                        "type": "string",
+                        "enum": [ "Telemetry_Listener" ]
+                    },
+                    "enable": {
+                        "default": true,
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/enable"
+                            }
+                        ]
+                    },
+                    "trace": {
+                        "default": false,
+                        "oneOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/trace"
+                            },
+                            {
+                                "$ref": "base_schema.json#/definitions/traceV2"
+                            }
+                        ]
+                    },
+                    "port": {
+                        "minimum": 1024,
+                        "maximum": 65535,
+                        "default": 6514,
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/port"
+                            }
+                        ]
+                    },
+                    "tag": {
+                        "$comment": "Deprecated! Use actions with a setTag action.",
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/tag"
+                            }
+                        ]
+                    },
+                    "match": {
+                        "default": "",
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/match"
+                            }
+                        ]
+                    },
+                    "actions": {
+                        "title": "Actions",
+                        "description": "Actions to be performed on the listener.",
+                        "default": [
+                            {
+                                "setTag": {
+                                    "tenant": "`T`",
+                                    "application": "`A`"
+                                }
+                            }
+                        ],
+                        "allOf": [{ "$ref": "actions_schema.json#/definitions/inputDataStreamActionsChain" }]
+                    }
+                },
+                "additionalProperties": false
+            },
+            "else": {}
+        }
+    ]
+}

--- a/src/schema/1.31.0/namespace_schema.json
+++ b/src/schema/1.31.0/namespace_schema.json
@@ -1,0 +1,92 @@
+{
+    "$id": "namespace_schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry Streaming Namespace schema",
+    "description": "",
+    "type": "object",
+    "definitions": {
+        "namespace": {
+            "required": [
+                "class"
+            ],
+            "type": "object",
+            "properties": {
+                "class": {
+                    "title": "Class",
+                    "description": "Telemetry Streaming Namespace class",
+                    "type": "string",
+                    "enum": [ "Telemetry_Namespace" ]
+                }
+            },
+            "additionalProperties": {
+                "$comment": "All objects supported under a Telemetry Namespace",
+                "properties": {
+                    "class": {
+                        "title": "Class",
+                        "type": "string",
+                        "enum": [
+                            "Telemetry_System",
+                            "Telemetry_System_Poller",
+                            "Telemetry_Listener",
+                            "Telemetry_Consumer",
+                            "Telemetry_Pull_Consumer",
+                            "Telemetry_iHealth_Poller",
+                            "Telemetry_Endpoints",
+                            "Shared"
+                        ]
+                    }
+                },    
+                "allOf": [
+                    {
+                        "$ref": "system_schema.json#"
+                    },
+                    {
+                        "$ref": "system_poller_schema.json#"
+                    },
+                    {
+                        "$ref": "listener_schema.json#"
+                    },
+                    {
+                        "$ref": "consumer_schema.json#"
+                    },
+                    {
+                        "$ref": "pull_consumer_schema.json#"
+                    },
+                    {
+                        "$ref": "ihealth_poller_schema.json#"
+                    },
+                    {
+                        "$ref": "endpoints_schema.json#"
+                    },
+                    {
+                        "$ref": "shared_schema.json#"
+                    }
+                ]
+            }
+        }
+    },
+    "allOf": [
+        {
+            "if": { "properties": { "class": { "const": "Telemetry_Namespace" } } },
+            "then": {
+                "required": [
+                    "class"
+                ],
+                "properties": {
+                    "class": {
+                        "title": "Class",
+                        "description": "Telemetry Streaming Namespace class",
+                        "type": "string",
+                        "enum": [ "Telemetry_Namespace" ]
+                    }
+                },
+                "allOf": [
+                    {
+                        "$ref": "#/definitions/namespace"
+                    }
+                ]
+            },
+            "else": {}
+        }
+    ]
+}

--- a/src/schema/1.31.0/pull_consumer_schema.json
+++ b/src/schema/1.31.0/pull_consumer_schema.json
@@ -1,0 +1,101 @@
+{
+    "$id": "pull_consumer_schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry Streaming Pull Consumer schema",
+    "description": "",
+    "type": "object",
+    "allOf": [
+        {
+            "if": { "properties": { "class": { "const": "Telemetry_Pull_Consumer" } } },
+            "then": {
+                "required": [
+                    "class",
+                    "type",
+                    "systemPoller"
+                ],
+                "properties": {
+                    "class": {
+                        "title": "Class",
+                        "description": "Telemetry Streaming Pull Consumer class",
+                        "type": "string",
+                        "enum": [ "Telemetry_Pull_Consumer" ]
+                    },
+                    "enable": {
+                        "default": true,
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/enable"
+                            }
+                        ]
+                    },
+                    "trace": {
+                        "default": false,
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/trace"
+                            }
+                        ]
+                    },
+                    "type": {
+                        "title": "Type",
+                        "description": "" ,
+                        "type": "string",
+                        "enum": [
+                            "default",
+                            "Prometheus"
+                        ]
+                    },
+                    "systemPoller": {
+                        "title": "Pointer to System Poller(s)",
+                        "anyOf": [
+                            {
+                                "$ref": "system_poller_schema.json#/definitions/systemPollerPointerRef"
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "system_poller_schema.json#/definitions/systemPollerPointerRef"
+                                        }
+                                    ]
+                                },
+                                "minItems": 1
+                            }
+                        ]
+                    }
+                },
+                "allOf": [
+                    {
+                        "$comment": "This allows enforcement of no additional properties in this nested schema - could reuse above properties but prefer a separate block",
+                        "properties": {
+                            "class": {},
+                            "enable": {},
+                            "trace": {},
+                            "type": {},
+                            "systemPoller": {}
+                        },
+                        "additionalProperties": false
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "default" } } },
+                        "then": {
+                            "required": [],
+                            "properties": {}
+                        },
+                        "else": {}
+                    },
+                    {
+                        "if": { "properties": { "type": { "const": "Prometheus" } } },
+                        "then": {
+                            "required": [],
+                            "properties": {}
+                        },
+                        "else": {}
+                    }
+                ]
+            },
+            "else": {}
+        }
+    ]
+}

--- a/src/schema/1.31.0/shared_schema.json
+++ b/src/schema/1.31.0/shared_schema.json
@@ -1,0 +1,50 @@
+{
+    "$id": "shared_schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry streaming Shared schema",
+    "description": "",
+    "type": "object",
+    "allOf": [
+        {
+            "if": { "properties": { "class": { "const": "Shared" } } },
+            "then": {
+                "required": [
+                    "class"
+                ],
+                "properties": {
+                    "class": {
+                        "title": "Class",
+                        "description": "Telemetry streaming Shared class",
+                        "type": "string",
+                        "enum": [ "Shared" ]
+                    }
+                },
+                "additionalProperties": {
+                    "properties": {
+                        "class": {
+                            "title": "Class",
+                            "type": "string",
+                            "enum": [
+                                "Constants",
+                                "Secret"
+                            ]
+                        }
+                    },    
+                    "allOf": [
+                        {
+                            "if": { "properties": { "class": { "const": "Constants" } } },
+                            "then": { "$ref": "base_schema.json#/definitions/constants" },
+                            "else": {}
+                        },
+                        {
+                            "if": { "properties": { "class": { "const": "Secret" } } },
+                            "then": { "$ref": "base_schema.json#/definitions/secret" },
+                            "else": {}
+                        }
+                    ]
+                }
+            },
+            "else": {}
+        }
+    ]
+}

--- a/src/schema/1.31.0/system_poller_schema.json
+++ b/src/schema/1.31.0/system_poller_schema.json
@@ -1,0 +1,242 @@
+{
+    "$id": "system_poller_schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry Streaming system poller schema",
+    "description": "",
+    "type": "object",
+    "definitions": {
+        "systemPoller": {
+            "$comment": "system_schema.json should be updated when new property added",
+            "title": "System Poller",
+            "description": "",
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "default": true,
+                    "allOf": [
+                        {
+                            "$ref": "base_schema.json#/definitions/enable"
+                        }
+                    ]
+                },
+                "interval": {
+                    "title": "Collection interval (in seconds)",
+                    "description": "If endpointList is specified, minimum=1. Without endpointList, minimum=60 and maximum=60000. Allows setting interval=0 to not poll on an interval.",
+                    "type": "integer",
+                    "default": 300
+                },
+                "trace": {
+                    "$ref": "base_schema.json#/definitions/trace"
+                },
+                "tag": {
+                    "$comment": "Deprecated! Use actions with a setTag action.",
+                    "allOf": [
+                        {
+                            "$ref": "base_schema.json#/definitions/tag"
+                        }
+                    ]
+                },
+                "actions": {
+                    "title": "Actions",
+                    "description": "Actions to be performed on the systemPoller.",
+                    "default": [
+                        {
+                            "setTag": {
+                                "tenant": "`T`",
+                                "application": "`A`"
+                            }
+                        }
+                    ],
+                    "allOf": [{ "$ref": "actions_schema.json#/definitions/inputDataStreamActionsChain" }]
+                },
+                "endpointList": {
+                    "title": "Endpoint List",
+                    "description": "List of endpoints to use in data collection",
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "endpoints_schema.json#/definitions/endpointsPointerRef"
+                                    },
+                                    {
+                                        "$ref": "endpoints_schema.json#/definitions/endpointsItemPointerRef"
+                                    },
+                                    {
+                                        "if": { "required": [ "items" ]},
+                                        "then": {
+                                            "$ref": "endpoints_schema.json#/definitions/endpointsObjectRef"
+                                        },
+                                        "else": {
+                                            "$ref": "endpoints_schema.json#/definitions/endpointObjectRef"
+                                        }
+                                    }
+
+                                ]
+                            },
+                            "minItems": 1
+                        },
+                        {
+                            "$ref": "endpoints_schema.json#/definitions/endpointsPointerRef"
+                        },
+                        {
+                            "$ref": "endpoints_schema.json#/definitions/endpointsObjectRef"
+                        }
+                    ]
+                }
+            },
+            "oneOf": [
+                {
+                    "allOf": [
+                        {
+                            "if": { "required": [ "endpointList" ] },
+                            "then": {
+                                "properties": {
+                                    "interval": {
+                                        "minimum": 1
+                                    }
+                                }
+                            },
+                            "else": {
+                                "properties":{
+                                    "interval": {
+                                        "minimum": 60,
+                                        "maximum": 6000
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "allOf": [
+                        {
+                            "properties": {
+                                "interval": {
+                                    "enum": [0]
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "systemPollerPointerRef": {
+            "type": "string",
+            "minLength": 1,
+            "declarationClass": "Telemetry_System_Poller"
+        },
+        "systemPollerObjectRef": {
+            "allOf": [
+                {
+                    "$comment": "This allows enforcement of no additional properties in this nested schema - could reuse above properties but prefer a separate block",
+                    "properties": {
+                        "enable": {},
+                        "trace": {},
+                        "interval": {},
+                        "tag": {},
+                        "actions": {},
+                        "endpointList": {}
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "$ref": "#/definitions/systemPoller"
+                }
+            ]
+        }
+    },
+    "allOf": [
+        {
+            "if": { "properties": { "class": { "const": "Telemetry_System_Poller" } } },
+            "then": {
+                "required": [
+                    "class"
+                ],
+                "properties": {
+                    "class": {
+                        "title": "Class",
+                        "description": "Telemetry Streaming System Poller class",
+                        "type": "string",
+                        "enum": [ "Telemetry_System_Poller" ]
+                    },
+                    "host": {
+                        "$comment": "Deprecated! Use Telemetry_System to define target device",
+                        "default": "localhost",
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/host"
+                            }
+                        ]
+                    },
+                    "port": {
+                        "$comment": "Deprecated! Use Telemetry_System to define target device",
+                        "default": 8100,
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/port"
+                            }
+                        ]
+                    },
+                    "protocol": {
+                        "$comment": "Deprecated! Use Telemetry_System to define target device",
+                        "default": "http",
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/protocol"
+                            }
+                        ]
+                    },
+                    "allowSelfSignedCert": {
+                        "$comment": "Deprecated! Use Telemetry_System to define target device",
+                        "title": "Allow Self-Signed Certificate",
+                        "default": false,
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/allowSelfSignedCert"
+                            }
+                        ]
+                    },
+                    "enableHostConnectivityCheck": {
+                        "$comment": "Deprecated! Use Telemetry_System to define target device",
+                        "$ref": "base_schema.json#/definitions/enableHostConnectivityCheck"
+                    },
+                    "username": {
+                        "$comment": "Deprecated! Use Telemetry_System to define target device",
+                        "$ref": "base_schema.json#/definitions/username"
+                    },
+                    "passphrase": {
+                        "$comment": "Deprecated! Use Telemetry_System to define target device",
+                        "$ref": "base_schema.json#/definitions/secret"
+                    }
+                },
+                "allOf": [
+                    {
+                        "$comment": "This allows enforcement of no additional properties in this nested schema - could reuse above properties but prefer a separate block",
+                        "properties": {
+                            "class": {},
+                            "enable": {},
+                            "trace": {},
+                            "interval": {},
+                            "tag": {},
+                            "host": {},
+                            "port": {},
+                            "protocol": {},
+                            "allowSelfSignedCert": {},
+                            "enableHostConnectivityCheck": {},
+                            "username": {},
+                            "passphrase": {},
+                            "actions": {},
+                            "endpointList": {}
+                        },
+                        "additionalProperties": false
+                    },
+                    {
+                        "$ref": "#/definitions/systemPoller"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/src/schema/1.31.0/system_schema.json
+++ b/src/schema/1.31.0/system_schema.json
@@ -1,0 +1,121 @@
+{
+    "$id": "system_schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry Streaming System schema",
+    "description": "",
+    "type": "object",
+    "allOf": [
+        {
+            "if": { "properties": { "class": { "const": "Telemetry_System" } } },
+            "then": {
+                "required": [
+                    "class"
+                ],
+                "properties": {
+                    "class": {
+                        "title": "Class",
+                        "description": "Telemetry Streaming System class",
+                        "type": "string",
+                        "enum": [ "Telemetry_System" ]
+                    },
+                    "enable": {
+                        "title": "Enable all pollers attached to device",
+                        "default": true,
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/enable"
+                            }
+                        ]
+                    },
+                    "trace": {
+                        "$ref": "base_schema.json#/definitions/trace"
+                    },
+                    "host": {
+                        "title": "System connection address",
+                        "default": "localhost",
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/host"
+                            }
+                        ]
+                    },
+                    "port": {
+                        "title": "System connection port",
+                        "default": 8100,
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/port"
+                            }
+                        ]
+                    },
+                    "protocol": {
+                        "title": "System connection protocol",
+                        "default": "http",
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/protocol"
+                            }
+                        ]
+                    },
+                    "allowSelfSignedCert": {
+                        "title": "Allow Self-Signed Certificate",
+                        "default": false,
+                        "allOf": [
+                            {
+                                "$ref": "base_schema.json#/definitions/allowSelfSignedCert"
+                            }
+                        ]
+                    },
+                    "enableHostConnectivityCheck": {
+                        "$ref": "base_schema.json#/definitions/enableHostConnectivityCheck"
+                    },
+                    "username": {
+                        "title": "System Username",
+                        "$ref": "base_schema.json#/definitions/username"
+                    },
+                    "passphrase": {
+                        "title": "System Passphrase",
+                        "$ref": "base_schema.json#/definitions/secret"
+                    },
+                    "systemPoller": {
+                        "title": "System Poller declaration",
+                        "oneOf": [
+                            {
+                                "$ref": "system_poller_schema.json#/definitions/systemPollerPointerRef"
+                            },
+                            {
+                                "$ref": "system_poller_schema.json#/definitions/systemPollerObjectRef"
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "system_poller_schema.json#/definitions/systemPollerObjectRef"
+                                        },
+                                        {
+                                            "$ref": "system_poller_schema.json#/definitions/systemPollerPointerRef"
+                                        }
+                                    ]
+                                },
+                                "minItems": 1
+                            }
+                        ]
+                    },
+                    "iHealthPoller": {
+                        "title": "iHealth Poller declaration",
+                        "oneOf": [
+                            {
+                                "$ref": "ihealth_poller_schema.json#/definitions/iHealthPollerPointerRef"
+                            },
+                            {
+                                "$ref": "ihealth_poller_schema.json#/definitions/iHealthPollerObjectRef"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": false
+            }
+        }
+    ]
+}

--- a/test/unit/consumers/data/azureUtilTestsData.js
+++ b/test/unit/consumers/data/azureUtilTestsData.js
@@ -133,5 +133,35 @@ module.exports = {
                 expected: 'https://public-cloud-workspace-id.ods.opinsights.azure.com/api/logs?api-version=2016-04-01'
             }
         ]
+    },
+    getApiUrlCustomOpts: {
+        name: '.getApiUrl - URLs set in customOpts should override the default',
+        tests: [
+            {
+                name: 'should return customOpts value for managementUrl',
+                metadata: {},
+                config: {
+                    customOpts: [{
+                        name: 'managementUrl',
+                        value: 'https://management.azure.de'
+                    }]
+                },
+                apiType: 'management',
+                expected: 'https://management.azure.de'
+            },
+            {
+                name: 'should return customOpts value for opinsightsUrl, even if workspace ID is set to something else',
+                config: {
+                    workspaceId: 'not-used',
+                    customOpts: [{
+                        name: 'opinsightsUrl',
+                        value: 'https://german-cloud-workspace-id.ods.opinsights.azure.de/api/logs?api-version=2016-04-01'
+                    }]
+                },
+                metadata: {},
+                apiType: 'opinsights',
+                expected: 'https://german-cloud-workspace-id.ods.opinsights.azure.de/api/logs?api-version=2016-04-01'
+            }
+        ]
     }
 };


### PR DESCRIPTION
@mdditt2000

#### What issues does this address?

- Fixes #213 

#### What does this change do?
The schema already had a `customOpts` array to specify custom options. This change enables this array for the Azure Log Analytics consumer. When a `managementUrl` or `opinsightsUrl` custom option is detected, that URL is used instead of attempting to calculate the URL from the region/identity.

#### Where should the reviewer start?
The unit tests and comments in the code/docs demonstrate how to use these new options. You could setup a consumer with a 'westus' (public cloud region) but specify USGov URLs in customOpts and verify that the consumer is using the specific values.

#### Any background context?
As the issue points out, it will not be possible to construct every URL based on information present on the VM at this time. For some clouds, the user will just have to specify the URL to use. 
