### PR TITLE
removed network interface filters

### DIFF
--- a/src/lib/properties.json
+++ b/src/lib/properties.json
@@ -286,7 +286,7 @@
             "key": "networkInterfaces",
             "normalization": [
                 {
-                    "filterKeys": { "exclude": [ "counters.errorsAll", "counters.dropsAll", "counters.pktsIn", "counters.pktsOut", "mediaActive", "tmName" ] }
+                    "filterKeys": { "exclude": [ ] }
                 },
                 {
                     "renameKeys": { "patterns": { "net/interface": { "pattern": "([0-9]+\\.[0-9]+|(?!\/)mgmt(?=\/))" } } }


### PR DESCRIPTION
@grf5

#### What issues does this address?
https://github.com/F5Networks/f5-telemetry-streaming/issues/264

#### What does this change do?
Removes filters from the network interface stats

#### Where should the reviewer start?
Line 289 of properties.json

#### Any background context?
As requested by a customer